### PR TITLE
Run the NixOS test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
     branches: [main]
 
 jobs:
+  NixOSTest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v16
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Run the NixOS Test
+        run: nix build .#hydra-minio
+
   Terraform:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I don't know if GitHub Actions will actually be able to run this test, but let's find out. If the runners expose KVM then we should be good.